### PR TITLE
Slack へ期限超過タスクを通知

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,3 +46,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'slack-api'

--- a/Gemfile
+++ b/Gemfile
@@ -48,3 +48,4 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'slack-api'
+gem 'whenever', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,15 @@ GEM
     concurrent-ruby (1.0.2)
     debug_inspector (0.0.2)
     erubis (2.7.0)
+    eventmachine (1.2.0.1)
     execjs (2.7.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.10.0)
+      faraday (>= 0.7.4, < 0.10)
+    faye-websocket (0.9.2)
+      eventmachine (>= 0.12.0)
+      websocket-driver (>= 0.5.1)
     ffi (1.9.14)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
@@ -77,6 +85,7 @@ GEM
     mini_portile2 (2.1.0)
     minitest (5.9.0)
     multi_json (1.12.1)
+    multipart-post (2.0.0)
     nio4r (1.2.1)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
@@ -120,6 +129,11 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    slack-api (1.2.4)
+      faraday (>= 0.7, < 0.10)
+      faraday_middleware (~> 0.8)
+      faye-websocket (~> 0.9.2)
+      multi_json (~> 1.0, >= 1.0.3)
     spring (1.7.2)
     spring-watcher-listen (2.0.0)
       listen (>= 2.7, < 4.0)
@@ -163,6 +177,7 @@ DEPENDENCIES
   puma (~> 3.0)
   rails (~> 5.0.0)
   sass-rails (~> 5.0)
+  slack-api
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
@@ -172,4 +187,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   1.12.5
+   1.13.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
     arel (7.1.1)
     builder (3.2.2)
     byebug (9.0.5)
+    chronic (0.10.2)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.2.x)
@@ -164,6 +165,8 @@ GEM
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    whenever (0.9.7)
+      chronic (>= 0.6.3)
 
 PLATFORMS
   ruby
@@ -185,6 +188,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console
+  whenever
 
 BUNDLED WITH
    1.13.2

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,6 @@
 class Task < ApplicationRecord
   enum status: { todo: 0, doing: 1, done: 2 }
   validates :content, presence: true
+
+  scope :unfinished, -> { where(status: :todo).or(where(status: :doing)) }
 end

--- a/app/views/tasks/index.json.jbuilder
+++ b/app/views/tasks/index.json.jbuilder
@@ -1,4 +1,4 @@
 json.array!(@tasks) do |task|
-  json.extract! task, :id, :content, :status
+  json.extract! task, :id, :content, :status, :deadline
   json.url task_url(task, format: :json)
 end

--- a/app/views/tasks/show.json.jbuilder
+++ b/app/views/tasks/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! @task, :id, :content, :status
+json.extract! @task, :id, :content, :status, :deadline

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,5 +11,6 @@ module WebdbTodo
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+    config.time_zone = 'Asia/Tokyo'
   end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,7 @@
+set :output, "/log/cron_log.log"
+set :environment, :production
+
+work_hour = (9..18).map { |h| "#{h}:00" }
+every 1.hours, at: work_hour do
+  rake "todo_tasks:check_overdues"
+end

--- a/db/migrate/20161011013706_add_deadline_to_task.rb
+++ b/db/migrate/20161011013706_add_deadline_to_task.rb
@@ -1,0 +1,5 @@
+class AddDeadlineToTask < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tasks, :deadline, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160904054321) do
+ActiveRecord::Schema.define(version: 20161011013706) do
 
   create_table "tasks", force: :cascade do |t|
-    t.text    "content"
-    t.integer "status",  limit: 4
+    t.text     "content"
+    t.integer  "status",   limit: 4
+    t.datetime "deadline"
   end
 
 end

--- a/lib/tasks/check_overdue_tasks.rake
+++ b/lib/tasks/check_overdue_tasks.rake
@@ -7,23 +7,18 @@ namespace :todo_tasks do
       config.token = ENV['SLACK_TOKEN']
     end
 
-    me = my_info
-    unless me
+    unless (my_info = find_my_info)
       puts 'slack user not found'
       exit
     end
 
-    Slack.chat_postMessage(channel: me['id'], text: "期限すぎてますよ〜 at #{now}\n#{overdue_tasks}")
+    Slack.chat_postMessage(channel: my_info['id'], text: "期限すぎてますよ〜 at #{now}\n#{overdue_tasks}")
   end
 
-  def my_info
-    Slack.im_list['ims'].each do |im|
-      user_info = Slack.users_info(user: im['user'])['user']
-      if user_info['name'] == ENV['SLACK_USER_NAME']
-        return user_info
-      end
+  def find_my_info
+    Slack.users_list['members'].find do |user|
+      user['name'] == ENV['SLACK_USER_NAME']
     end
-    nil
   end
 
   def overdue_tasks

--- a/lib/tasks/check_overdue_tasks.rake
+++ b/lib/tasks/check_overdue_tasks.rake
@@ -1,0 +1,38 @@
+require 'slack'
+
+namespace :todo_tasks do
+  desc 'Check overdue tasks'
+  task check_overdues: :environment do
+    Slack.configure do |config|
+      config.token = ENV['SLACK_TOKEN']
+    end
+
+    me = my_info
+    unless me
+      puts 'slack user not found'
+      exit
+    end
+
+    Slack.chat_postMessage(channel: me['id'], text: "期限すぎてますよ〜 at #{now}\n#{overdue_tasks}")
+  end
+
+  def my_info
+    Slack.im_list['ims'].each do |im|
+      user_info = Slack.users_info(user: im['user'])['user']
+      if user_info['name'] == ENV['SLACK_USER_NAME']
+        return user_info
+      end
+    end
+    nil
+  end
+
+  def overdue_tasks
+    overdues = Task.unfinished.where.not(deadline: nil)
+                              .where('deadline <= ?', Time.now)
+    overdues.map { |o| "#{o.content} #{o.deadline.strftime('%F %H:%M')}" }.join("\n")
+  end
+
+  def now
+    Time.now.strftime('%F %H:%M')
+  end
+end


### PR DESCRIPTION
## 何を解決するのか

期限が過ぎているタスクはアプリを開かないと確認できず、タスク消化忘れの可能性があります。
この問題を解決するために、Slack へ期限が過ぎているタスクのリストを定期的に通知できるようにします。
## 解決方法

Slack へ期限切れタスクリストを送信する Rake タスク `check_overdue_tasks` を、Whenever を使って 9 - 18 時の正時にキックしています。

Slack API 用の環境変数設定が必要です。
- `SLACK_USER_NAME`
  - Slack の通知先ユーザ名
- `SLACK_TOKEN`
  - Slack API のトークン（開発者用サイトで取得）
## 重点的に見てほしい箇所
- whenever 設定ファイル `schedule.rb` が正しく定期実行できる設定となっているか
- `check_overdue_tasks.rake` の期限切れタスク取得処理 `overdue_tasks` が正しく処理できているか
