### PR TITLE
フォームが空白のとき登録ボタンを無効化

### DIFF
--- a/app/assets/javascripts/TaskForm.js
+++ b/app/assets/javascripts/TaskForm.js
@@ -2,6 +2,11 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 export default class TaskForm extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { activateSubmit: false };
+  }
+
   handleSubmit(e){
     e.preventDefault();
     var content = ReactDOM.findDOMNode(this.refs.content).value.trim();
@@ -13,13 +18,22 @@ export default class TaskForm extends React.Component {
     return;
   }
 
+  handleChange(e) {
+    var content = ReactDOM.findDOMNode(this.refs.content).value.trim();
+    if (!content || /\s+/.test(content)) {
+      this.setState({ activateSubmit: false });
+    } else {
+      this.setState({ activateSubmit: true });
+    }
+  }
+
   render() {
     return (
-      <form className="todoForm" onSubmit={this.handleSubmit.bind(this)}>
+      <form className="todoForm" onSubmit={this.handleSubmit.bind(this)} onChange={this.handleChange.bind(this)}>
         <div className="input-group">
           <input type="text" className="form-control" placeholder="ToDo" ref="content" />
           <span className="input-group-btn">
-            <input type="submit" className="btn btn-primary" value="登録" />
+            <input type="submit" className="btn btn-primary" value="登録" disabled={!this.state.activateSubmit} />
           </span>
         </div>
       </form>

--- a/app/assets/javascripts/TaskForm.js
+++ b/app/assets/javascripts/TaskForm.js
@@ -15,6 +15,7 @@ export default class TaskForm extends React.Component {
     }
     this.props.onTaskSubmit({content: content, status: 'todo'});
     ReactDOM.findDOMNode(this.refs.content).value = '';
+    this.setState({ activateSubmit: false });
     return;
   }
 


### PR DESCRIPTION
@qkake @udzura 確認お願いします。
## 何を解決するのか

追加課題「フォームが空白のときの対処」です。
フォームが空もしくは空白文字だけからなるとき、登録ボタンを無効化して、名前のないタスクを submit できないようにします。
`handleChange` 内でフォームの内容をチェックして、登録ボタンの有効無効を切り替えています。
## レビューポイント
- `handleChange` の空白判定処理
## 注意事項

フォームが空白のときにアラートを出すとアプリを使うときにつらい感じなので、登録ボタンの無効化に変えました。アラートを出す方法は次の手順で実現できます。
- `handleBlur` にフォームからフォーカスが外れたときにフォーム内容が空もしくは空白であれば、アラートを表示する処理を書く
- `<input type="submit" ...>` の `onBlur` に `handleBlur` を指定する
