### PR TITLE
リスト上の Task のドラッグアンドドロップを有効化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,3 +56,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'slack-api'
 gem 'whenever', require: false
+gem 'ranked-model'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,8 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (11.2.2)
+    ranked-model (0.4.0)
+      activerecord (>= 3.1.12)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
@@ -204,6 +206,7 @@ DEPENDENCIES
   puma (~> 3.0)
   rails (~> 5.0.0)
   rails-controller-testing
+  ranked-model
   rspec-rails (~> 3.5.0)
   sass-rails (~> 5.0)
   slack-api

--- a/app/assets/javascripts/Task.js
+++ b/app/assets/javascripts/Task.js
@@ -2,9 +2,11 @@ import React from "react";
 import { DragDropContext, DropTarget, DragSource } from "react-dnd";
 
 @DropTarget('item', {
-  hover(hoverProps, monitor, hoverComponent) {
+  drop(dropProps, monitor, dropComponent) {
     let dragProps = monitor.getItem();
-    console.log(hoverProps.id, dragProps.id);
+    if (dropProps.id !== dragProps.id) {
+      dragProps.onDrop(dragProps.id, dropProps.id);
+    }
   },
 }, (connect) => {
   return {
@@ -24,7 +26,7 @@ import { DragDropContext, DropTarget, DragSource } from "react-dnd";
 export default class Task extends React.Component {
   render() {
     return this.props.connectDragSource(this.props.connectDropTarget(
-      <tr key={this.props.id}>
+        <tr key={this.props.id} className="item" data-model_name="Task" data-update_url={"tasks/" + this.props.id + "/sort"}>
         <td>
           {this.props.content}
         </td>

--- a/app/assets/javascripts/Task.js
+++ b/app/assets/javascripts/Task.js
@@ -1,8 +1,29 @@
 import React from "react";
+import { DragDropContext, DropTarget, DragSource } from "react-dnd";
 
+@DropTarget('item', {
+  hover(hoverProps, monitor, hoverComponent) {
+    let dragProps = monitor.getItem();
+    console.log(hoverProps.id, dragProps.id);
+  },
+}, (connect) => {
+  return {
+    connectDropTarget: connect.dropTarget(),
+  }
+})
+@DragSource('item', {
+  beginDrag(props) {
+    return props
+  }
+}, (connect, monitor) => {
+  return {
+    connectDragSource: connect.dragSource(),
+    isDragging: monitor.isDragging()
+  }
+})
 export default class Task extends React.Component {
   render() {
-    return (
+    return this.props.connectDragSource(this.props.connectDropTarget(
       <tr key={this.props.id}>
         <td>
           {this.props.content}
@@ -15,7 +36,7 @@ export default class Task extends React.Component {
           </select>
         </td>
       </tr>
-    );
+    ));
   }
 
   handleUpdate(e){

--- a/app/assets/javascripts/TaskApp.js
+++ b/app/assets/javascripts/TaskApp.js
@@ -54,7 +54,7 @@ export default class TaskApp extends React.Component {
       <div className="taskApp">
         <TaskForm
         onTaskSubmit={this.handleTaskSubmit.bind(this)} />
-        <table className="table table-striped">
+        <table className="table table-striped table-sortable">
           <thead>
             <tr>
               <th>Content</th>

--- a/app/assets/javascripts/TaskList.js
+++ b/app/assets/javascripts/TaskList.js
@@ -1,17 +1,33 @@
 import React from "react";
 import Task from "./Task";
+import { DragDropContext, DropTarget, DragSource } from "react-dnd";
+import ReactDnDHTML5Backend from "react-dnd-html5-backend";
 
+@DragDropContext(ReactDnDHTML5Backend)
 export default class TaskList extends React.Component {
   render() {
-    var tasks = this.props.data.map((task) => {
-      return(
-        <Task key={task.id} id={task.id} 
-              content={task.content} status={task.status} onTaskUpdate={this.props.onTaskUpdate} />
-      );
-    });
-    return (
+    return(
       <tbody>
-        {tasks}
+      {
+        this.props.data.map((task) => {
+          return <Task
+          key={task.id} id={task.id}
+          content={task.content} status={task.status} onTaskUpdate={this.props.onTaskUpdate}
+          onDrop={
+            (toID, fromID) => {
+              const tasks = this.props.data.slice();
+              const toIndex = tasks.findIndex(i => i.id == toID);
+              const fromIndex = tasks.findIndex(i => i.id == fromID);
+              const toTask = tasks[toIndex];
+              const fromTask = tasks[fromIndex];
+              tasks[toIndex] = fromTask;
+              tasks[fromIndex] = toTask;
+              this.setState({tasks});
+            }
+          }
+          />
+        })
+      }
       </tbody>
     );
   }

--- a/app/assets/javascripts/TaskList.js
+++ b/app/assets/javascripts/TaskList.js
@@ -2,6 +2,7 @@ import React from "react";
 import Task from "./Task";
 import { DragDropContext, DropTarget, DragSource } from "react-dnd";
 import ReactDnDHTML5Backend from "react-dnd-html5-backend";
+import request from 'superagent';
 
 @DragDropContext(ReactDnDHTML5Backend)
 export default class TaskList extends React.Component {
@@ -23,6 +24,21 @@ export default class TaskList extends React.Component {
               tasks[toIndex] = fromTask;
               tasks[fromIndex] = toTask;
               this.setState({tasks});
+
+              request.put("/tasks/" + fromTask.id + "/sort")
+                .accept('application/json')
+                .send({task: { id: fromTask.id,
+                               content: fromTask.content,
+                               row_order_position: toIndex }})
+                .end((err, res) => {
+                  if (err || !res.ok) {
+                    console.error(this.props.url,
+                                  status,
+                                  err.toString());
+                  } else {
+                    this.setState({data: tasks});
+                  }
+                });
             }
           }
           />

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -48,6 +48,12 @@ class TasksController < ApplicationController
     end
   end
 
+  def sort
+    task = Task.find(params[:task_id])
+    task.update(task_params)
+    render nothing: true
+  end
+
   private
 
   def set_task
@@ -55,6 +61,6 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:content, :status)
+    params.require(:task).permit(:content, :status, :row_order_position)
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.rank(:row_order)
   end
 
   def show

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,7 @@
 class Task < ApplicationRecord
+  include RankedModel
+  ranks :row_order
+
   enum status: { todo: 0, doing: 1, done: 2 }
   validates :content, presence: true
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
-  resources :tasks
+  resources :tasks do
+    put :sort
+  end
   root to: 'welcome#index'
 end

--- a/db/migrate/20161018035734_add_row_order_to_tasks.rb
+++ b/db/migrate/20161018035734_add_row_order_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddRowOrderToTasks < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tasks, :row_order, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161011013706) do
+ActiveRecord::Schema.define(version: 20161018035734) do
 
   create_table "tasks", force: :cascade do |t|
     t.text     "content"
-    t.integer  "status",   limit: 4
+    t.integer  "status",    limit: 4
     t.datetime "deadline"
+    t.integer  "row_order"
   end
 
 end

--- a/package.json
+++ b/package.json
@@ -20,8 +20,11 @@
     "watchify": "^3.7.0"
   },
   "dependencies": {
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-react": "^6.16.0",
     "react": "^15.3.2",
+    "react-dnd": "^2.1.4",
+    "react-dnd-html5-backend": "^2.1.2",
     "react-dom": "^15.3.2",
     "superagent": "^2.3.0"
   },
@@ -29,6 +32,9 @@
     "presets": [
       "es2015",
       "react"
+    ],
+    "plugins": [
+      "transform-decorators-legacy"
     ]
   }
 }


### PR DESCRIPTION
@qkake @udzura 確認お願いします。
## 何を解決するのか

react-dnd を利用して、リスト上の Task の項目をドラッグアンドドロップで並べ替えできるようにします。
ranked-model を使って DB に order を保存しているので、画面更新後も順番は保存されます。
- [react-dnd](https://github.com/gaearon/react-dnd)
- [ranked-model](https://github.com/mixonic/ranked-model)
## 注意点

react-dnd で JS の decorator が必要、かつ Babel v6 が decorator 未サポートなので、babel-plugin-transform-decorators-legacy をインストールしています。
### decorator

ES7 で入る機能で、今回の PR でいうところの `@DropTarget` のような記法で使えるものです。
デザインパターンの方とは別物。

機能は Java のアノテーションと似ていて、class などの直前に記述することで、それらに対する付加情報を与えることができます。
Java のアノテーションはフレームワークで用いられることが多い気がします。
### react-dnd

react-dnd は redux 作者が作っていてドキュメントが豊富なことから、今回選定しました。
react-dnd では、ドラッグ対象領域、ドラッグ対象、ドロップ対象の class それぞれについて、decorator でコールバック情報などを注入します。
今回は、ドラッグ対象領域が `TaskList` なので、こちらに `@DragDropContext` を、
ドラッグ、ドロップ対象が `Task` なので、こちらに `@DropTarget`, `@DragTarget` を設定しています。
## 現状の問題点
- ドラッグアンドドロップ後のリスト更新が遅い
- アニメーションがない
## 参考
- [react-dnd これだけ抑えておけばおｋ - Qiita](http://qiita.com/mizchi/items/9a426af4fe919cd9d9d5)
- [Rails 4で作るドラッグアンドドロップで表示順を変更できるサンプルアプリ(スクリーンキャスト付き) - Qiita](http://qiita.com/jnchito/items/391fb16d3f69fda9bdae)
